### PR TITLE
Feat/ec2-driver: Bootstrap `ec2` Driver Construct

### DIFF
--- a/internal/drivers/ec2/doc.go
+++ b/internal/drivers/ec2/doc.go
@@ -1,0 +1,18 @@
+// # Overview
+//
+// ec2 provides machinery for bootstrapping and tearing down AWS EC2 instances.
+//
+// # Compute (`Instance`)
+//
+// The primary interface exposed by this package is type `Instance`. All
+// `Instance` inputs are abstractions over `ec2.RunInstancesInput`. This allows
+// test authors to provide arbitrary desired test environment constraints (CPU
+// count, memory capacity, ...) from which this package will analyze all
+// instance types it is aware of and select the cheapest which _completely_
+// fulfills all inputs.
+package ec2
+
+import "github.com/aws/aws-sdk-go-v2/service/ec2"
+
+// For more reading on abstracted inputs, see:
+var _ ec2.RunInstancesInput

--- a/internal/drivers/ec2/driver.go
+++ b/internal/drivers/ec2/driver.go
@@ -1,0 +1,64 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+)
+
+var _ drivers.Tester = (*Driver)(nil)
+
+type Driver struct {
+	/////////////////////////////////////////////////////////////////////////////
+	// Public API
+
+	// The AMI to launch the instance with
+	AMI string
+
+	// The instance architecture
+	Arch types.ArchitectureType
+
+	// The desired instance type (ex: `t3.medium`).
+	//
+	// NOTE: If provided, this input supersedes all other configuration (VCPUs,
+	// memory, GPUs, etc.)!
+	InstanceType types.InstanceType
+
+	// Whether the instance type is eligible for free tier use
+	FreeTierEligible bool
+
+	// Instance virtual processor configuration
+	Proc Proc
+
+	// Instance physical memory configuration
+	Memory Memory
+
+	// Instance storage configuration
+	Disks []Disk
+
+	// Instance accelerator configuration
+	GPU GPU
+
+	/////////////////////////////////////////////////////////////////////////////
+	// Unexported Fields
+
+	// client holds a configured ec2 client for use in the `Setup` and `Teardown`
+	// phases.
+	client *ec2.Client
+
+	// instanceID holds the launched instance ID for teardown later
+	instanceID *string
+
+	// instanceAddr holds the public IP address of the launched instance
+	instanceAddr *string
+}
+
+func (self *Driver) SetClient(client *ec2.Client) {
+	self.client = client
+}
+
+var DriverDefault = &Driver{
+	AMI:          "TODO",
+	Arch:         types.ArchitectureTypeX8664,
+	InstanceType: types.InstanceTypeT3Medium,
+}

--- a/internal/drivers/ec2/gpu.go
+++ b/internal/drivers/ec2/gpu.go
@@ -1,0 +1,34 @@
+package ec2
+
+// GPU describes an input-configurable GPU which will be applied as a constraint
+// against the selectable instances
+type GPU struct {
+	// The desired GPU kind.
+	//
+	// Default: `GPUKindNone`
+	Kind GPUKind
+
+	// The number of desired GPUs for the instance.
+	//
+	// If `Kind` is set but this is not, it will default to `1`.
+	Count uint8
+
+	// The desired GPU driver version
+	Driver string
+}
+
+// Describes the kinds of GPUs from which we can choose.
+type GPUKind = string
+
+const (
+	GPUKindNone GPUKind = "none"
+	GPUKindM60  GPUKind = "M60"
+	GPUKindK80  GPUKind = "K80"
+	GPUKindA10G GPUKind = "A10G"
+	GPUKindL4   GPUKind = "L4"
+	GPUKindL40S GPUKind = "L40S"
+	GPUKindV100 GPUKind = "V100"
+	GPUKindA100 GPUKind = "A100"
+	GPUKindH100 GPUKind = "H100"
+	GPUKindH200 GPUKind = "H200"
+)

--- a/internal/drivers/ec2/memory.go
+++ b/internal/drivers/ec2/memory.go
@@ -1,0 +1,12 @@
+package ec2
+
+// Memory describes the user-configurable physical memory constraints for a
+// desired instance.
+type Memory struct {
+	// The desired instance physical memory capacity
+	//
+	// This is `fmt.Scan`ed and the unit of memory can case-insensitively be
+	// specified like `1000MB` or `1GB`. All units are evaluated as 2^(n) bytes,
+	// not bits as lowercase might typically indicate.
+	Capacity string
+}

--- a/internal/drivers/ec2/proc.go
+++ b/internal/drivers/ec2/proc.go
@@ -1,0 +1,13 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+type Proc struct {
+	// The processor architecture
+	Architecture types.ArchitectureType
+
+	// The number of logical processors
+	VCPUs uint16
+}

--- a/internal/drivers/ec2/run.go
+++ b/internal/drivers/ec2/run.go
@@ -1,0 +1,15 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/chainguard-dev/terraform-provider-imagetest/internal/drivers"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func (self Driver) Run(ctx context.Context, name name.Reference) (*drivers.RunResult, error) {
+	// ???
+	//
+	// Profit
+	return nil, nil
+}

--- a/internal/drivers/ec2/setup.go
+++ b/internal/drivers/ec2/setup.go
@@ -1,0 +1,9 @@
+package ec2
+
+import (
+	"context"
+)
+
+func (self *Driver) Setup(ctx context.Context) error {
+	return nil
+}

--- a/internal/drivers/ec2/storage.go
+++ b/internal/drivers/ec2/storage.go
@@ -1,0 +1,17 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Disk describes an EC2 instance volume.
+type Disk struct {
+	// Type of disk (ex: SSD, NVME, tape)
+	Kind types.DiskType
+
+	// Disk capacity (in gigabytes)
+	Capacity uint16
+
+	// Whether the disk supports NVME
+	NVMESupport bool
+}

--- a/internal/drivers/ec2/teardown.go
+++ b/internal/drivers/ec2/teardown.go
@@ -1,0 +1,8 @@
+package ec2
+
+import "context"
+
+func (self Driver) Teardown(ctx context.Context) error {
+	// Destroy instance
+	return nil
+}


### PR DESCRIPTION
https://github.com/chainguard-dev/terraform-provider-imagetest/pull/430